### PR TITLE
My version of expected reward strategy

### DIFF
--- a/contract.js
+++ b/contract.js
@@ -1,70 +1,126 @@
 module.exports = class Contract {
     constructor() {
+        this.expectedRewardBlock = 0
+        this.expectedReward = 0
         this.totalDeposits = 0
-        this.cumulativeBlockDeposits = 0
-        this.expectedDistribution = 0
-        this.expectedReward = 0 
+        this.userDeposits = {}
+        this.userDALastUpdated = {}   // last block where user's deposit age was recalculated
+        this.totalDALastUpdated = 0
+        this.userDepositChanged = {}  // flag to be flushed on every reward distribution
+        this.userDepositAge = {}
+        this.totalDepositAge = 0
         this.totalULP = 0
         this.ULP = {}
-        this.stake = {}
+        this.lastRewardBlock = 0
         this.setExpectedReward(0, 100)
-        this.lastDistribution = 0
-        this.hasDeposited={}
     }
 
     setExpectedReward(amount, block){
         this.expectedReward = amount
-        this.expectedDistribution = block
+        this.expectedRewardBlock = block
+    }
+
+    _updateDeposit(user, currentBlock) {
+        // init values
+        if (this.userDeposits[user] === undefined) {
+            this.userDeposits[user] = 0
+        }
+        if (this.userDALastUpdated[user] === undefined) {
+            this.userDALastUpdated[user] = 0
+        }
+        // accumulate deposit age within the current distribution interval
+        if (this.userDALastUpdated[user] > this.lastRewardBlock || this.userDepositChanged[user]) {
+            // add deposit age from previous deposit age update till now
+            this.userDepositAge[user] += (currentBlock - this.userDALastUpdated[user]) * this.userDeposits[user]
+        } else {
+            // a reward has been distributed, update user deposit
+            this.userDeposits[user] = this.userBalance(user)
+            // count fresh deposit age from that reward distribution till now
+            this.userDepositAge[user] = (currentBlock - this.lastRewardBlock) * this.userDeposits[user]
+        }
+        // same with total deposit age
+        if (this.totalDALastUpdated > this.lastRewardBlock) {
+            this.totalDepositAge += (currentBlock - this.totalDALastUpdated) * this.totalDeposits
+        } else {
+            this.totalDepositAge = (currentBlock - this.lastRewardBlock) * this.totalDeposits
+        }
+        this.userDALastUpdated[user] = currentBlock
+        this.totalDALastUpdated = currentBlock
     }
 
     deposit(user, amount, currentBlock) {
-        if(this.hasDeposited[user]===undefined){
-            this.hasDeposited[user]={}
-        }
-        this.stake[user] = (this.stake[user]||0) + amount
-        if(!this.hasDeposited[user][this.lastDistribution]){
-            this.hasDeposited[user][this.lastDistribution] = true
-            this.cumulativeBlockDeposits += this.stake[user]*(this.expectedDistribution - currentBlock)
-        }else{
-            this.cumulativeBlockDeposits += amount*(this.expectedDistribution - currentBlock)
-        }
+        this._updateDeposit(user, currentBlock)
+        // update deposit amounts
+        this.userDeposits[user] += amount
         this.totalDeposits += amount
-
+        // calculate newly added expected deposit age to get user's added share
+        let addedExpectedDepositAge = amount * (this.expectedRewardBlock - currentBlock)
+        let totalExpectedDepositAge = this.totalDepositAge + this.totalDeposits * (this.expectedRewardBlock - currentBlock)
+        // TODO: their actual reward will differ because deposits after him will change total expected deposit age!
+        let userAddedExpectedReward = (addedExpectedDepositAge / totalExpectedDepositAge) * this.expectedReward
+        let userAddedShare = (amount + userAddedExpectedReward) / (this.totalDeposits + this.expectedReward)
+        // mint ULP tokens to represent the added share
         let newULP
-        if(this.totalULP === 0){
-            newULP = 1
-        }else{
-            const userBlockTime = (this.expectedDistribution - currentBlock) * amount / this.cumulativeBlockDeposits
-            const x = (amount + this.expectedReward * userBlockTime) / (this.totalDeposits + this.expectedReward )
-            newULP = x/(1 - x)*this.totalULP
+        if (this.totalULP == 0) {
+            newULP = 1.0
+        } else {
+            newULP = this.totalULP * userAddedShare / (1 - userAddedShare)
         }
         this.ULP[user] = (this.ULP[user]||0) + newULP
-        this.totalULP += newULP 
+        this.totalULP += newULP
+        this.userDepositChanged[user] = true
     }
 
     withdraw(user, amount, currentBlock) {
-        this.stake[user] -= amount
-        if(!this.hasDeposited[user][this.lastDistribution]){
-            this.hasDeposited[user][this.lastDistribution] = true
-            this.cumulativeBlockDeposits += this.stake[user]*(this.expectedDistribution - currentBlock)
-        }else{
-            this.cumulativeBlockDeposits -= amount*(this.expectedDistribution - currentBlock)
+        if (this.userBalance(user) < amount) {
+            return console.error('Not enough balance: user '+user+' has '+this.userBalance(user)+' but tried to withdraw '+amount)
         }
-
-        const withdrawnULP = amount * this.totalULP / this.totalDeposits
+        this._updateDeposit(user, currentBlock)
+        // update deposit amounts
+        this.userDeposits[user] -= amount
         this.totalDeposits -= amount
-        this.totalULP -= withdrawnULP 
-        this.ULP[user] -= withdrawnULP
+        // count deposit age already provided by the user in the current distribution interval
+        let userExpectedDepositAge = this.userDepositAge[user] + this.userDeposits[user] * (this.expectedRewardBlock - currentBlock)
+        let totalExpectedDepositAge = this.totalDepositAge + this.totalDeposits * (this.expectedRewardBlock - currentBlock)
+        // calculate user's fair share of total when the next reward arrives
+        let userExpectedReward = (userExpectedDepositAge / totalExpectedDepositAge) * this.expectedReward
+        let userShare = (this.userDeposits[user] + userExpectedReward) / (this.totalDeposits + this.expectedReward)
+        let burntULP
+        if (userShare == 1) {
+            // if the user is the only depositor in the pool, just reduce his ULP tokens proportionally
+            burntULP = this.totalULP * amount / (this.userDeposits[user] + amount)
+        } else {
+            // leave user's fair share of ULP and burn the rest
+            burntULP = (this.ULP[user] - userShare * this.totalULP)/(1 - userShare)
+        }
+        this.totalULP -= burntULP
+        this.ULP[user] -= burntULP
+        this.userDepositChanged[user] = true
     }
 
     distribute(reward, currentBlock) {
         this.totalDeposits += reward
-        this.cumulativeBlockDeposits = 0
-        this.lastDistribution = currentBlock
+        
+        // This is a non-O(1) operation, but it's only needed to handle deposits that happen in one block
+        // with a reward distribution to determine their sequence. This flag can be completely removed if
+        // we don't allow deposits/withdrawals in one block with distributions.
+        this.userDepositChanged = {}
+        
+        // to avoid having negative expected reward time we set expected reward block right here based on the previous reward time
+        let lastRewardPeriod = currentBlock - this.lastRewardBlock
+        this.setExpectedReward(reward, currentBlock + lastRewardPeriod)
+        this.lastRewardBlock = currentBlock
     }
 
     userBalance(user) {
-        return this.totalDeposits * (this.ULP[user]||0) / this.totalULP
+        if (this.userDALastUpdated[user] > this.lastRewardBlock || this.userDepositChanged[user]) {
+            return this.userDeposits[user] || 0
+        } else {
+            if (this.totalULP == 0) {
+                return 0;
+            }
+            return this.totalDeposits * (this.ULP[user]||0) / this.totalULP
+        }
     }
 
     getTotalDeposits() {

--- a/test.js
+++ b/test.js
@@ -215,7 +215,7 @@ describe('rewards distributed correctly', () => {
     describe('rewards distributed correctly after withdrawal with multiple deposits on the same block',()=>{
         const amount1 = 1000
         const amount2 = 1000
-        const amount3 = 1
+        const amount3 = 750
         const reward = 1000
 
         const block1 = 0
@@ -223,7 +223,7 @@ describe('rewards distributed correctly', () => {
         const block3 = 100
         const block4 = 100
 
-        const userADepositAge = (block4 - block1)*(amount1 - amount3) 
+        const userADepositAge = (block3 - block1)*amount1 + (block4 - block3)*(amount1 - amount3)
         const userBDepositAge = (block4 - block2)*amount2
         const totalDepositAge = userADepositAge + userBDepositAge
 
@@ -254,7 +254,7 @@ describe('rewards distributed correctly', () => {
         const block4 = 400
 
         const userADepositAge = (block4 - block1)*amount1 
-        const userBDepositAge = (block4 - block2)*(amount2 - amount3) 
+        const userBDepositAge = (block3 - block2)*amount2 + (block4 - block3)*(amount2 - amount3)
         const totalDepositAge = userADepositAge + userBDepositAge
         beforeEach(() => {
             contract.setExpectedReward(reward, block4)
@@ -284,7 +284,7 @@ describe('rewards distributed correctly', () => {
         const block4 = 10
         const block5 = 20
 
-        const userADepositAge = (block3 - block1)*(amount1 - amount2) + (block5 - block3)*(amount1 - amount2 + amount3)
+        const userADepositAge = (block2 - block1)*amount1 + (block3 - block2)*(amount1 - amount2) + (block5 - block3)*(amount1 - amount2 + amount3)
         const userBDepositAge = (block5 - block4)*amount4
         const totalDepositAge = userADepositAge + userBDepositAge
 
@@ -323,8 +323,8 @@ describe('rewards distributed correctly', () => {
         const block7 = 400
         const block8 = 500
 
-        const userADepositAge = (block7 - block1)*(amount1 - amount4) + (block8 - block7)*(amount1 - amount4 + amount7)
-        const userBDepositAge = (block6 - block2)*(amount2 - amount3 - amount5) + (block8 - block6)*(amount2 - amount3 - amount5 + amount6)
+        const userADepositAge = (block4 - block1)*amount1 + (block7 - block4)*(amount1 - amount4) + (block8 - block7)*(amount1 - amount4 + amount7)
+        const userBDepositAge = (block3 - block2)*amount2 + (block5 - block3)*(amount2 - amount3) + (block6 - block5)*(amount2 - amount3 - amount5) + (block8 - block6)*(amount2 - amount3 - amount5 + amount6)
         const totalDepositAge = userADepositAge + userBDepositAge
 
         beforeEach(() => {
@@ -386,7 +386,7 @@ describe('random scenarios', () => {
 
         const userADepositAge2 = (block8 - block4)*(amount1 + reward1*userADepositAge1/totalDepositAge1)
         const userBDepositAge2 = (block8 - block4)*(amount2 + reward1*userBDepositAge1/totalDepositAge1)
-        const userCDepositAge2 = (block6 - block4)*(amount3 - amount5 + reward1*userCDepositAge1/totalDepositAge1) + (block8 - block6)*(amount3 - amount5 + amount6 + reward1*userCDepositAge1/totalDepositAge1)
+        const userCDepositAge2 = (block5 - block4)*(amount3 + reward1*userCDepositAge1/totalDepositAge1) + (block6 - block5)*(amount3 - amount5 + reward1*userCDepositAge1/totalDepositAge1) + (block8 - block6)*(amount3 - amount5 + amount6 + reward1*userCDepositAge1/totalDepositAge1)
         const userDDepositAge2 = (block8 - block7)*amount7
         const totalDepositAge2 = userADepositAge2 + userBDepositAge2 + userCDepositAge2 + userDDepositAge2
 
@@ -399,10 +399,10 @@ describe('random scenarios', () => {
 
         beforeEach(() => {
             contract.setExpectedReward(reward1, block4)
-            contract.deposit(userA, amount1, block1)
-            contract.deposit(userB, amount2, block2)
-            contract.deposit(userC, amount3, block3)
-            contract.distribute(reward1, block4)
+            contract.deposit(userA, amount1, block1)    // 500, 20
+            contract.deposit(userB, amount2, block2)    // 700, 40
+            contract.deposit(userC, amount3, block3)    // 200, 45
+            contract.distribute(reward1, block4)        // 2000, 50
                 rewardA1 = contract.userBalance(userA)
                 rewardB1 = contract.userBalance(userB)
                 rewardC1 = contract.userBalance(userC)
@@ -486,8 +486,11 @@ describe('random scenarios', () => {
         contract.distribute(reward, block8) 
 
         const userADepositAge = 
-            (block5 - block1)*(amount1 - amount3 - amount4) +
-            (block7 - block5)*(amount1 - amount3 - amount4 + amount5 - amount6) + 
+            (block3 - block1)*amount1 +
+            (block4 - block3)*(amount1 - amount3) +
+            (block5 - block4)*(amount1 - amount3 - amount4) +
+            (block6 - block5)*(amount1 - amount3 - amount4 + amount5) +
+            (block7 - block6)*(amount1 - amount3 - amount4 + amount5 - amount6) + 
             (block8 - block7)*(amount1 - amount3 - amount4 + amount5 - amount6 + amount7)
         const userBDepositAge = (block8 - block2)*amount2
         const totalDepositAge = userADepositAge + userBDepositAge
@@ -518,9 +521,9 @@ describe('random scenarios', () => {
         const block8 = 30
         const block9 = 50
 
-        const userADepositAge = (block5 - block1)*(amount1 - amount4) + (block9 - block5)*(amount1 - amount4 + amount5 - amount8)
+        const userADepositAge = (block4 - block1)*amount1 + (block5 - block4)*(amount1 - amount4) + (block8 - block5)*(amount1 - amount4 + amount5) + (block9 - block8)*(amount1 - amount4 + amount5 - amount8)
         const userBDepositAge = (block9 - block2)*amount2
-        const userCDepositAge = (block7 - block3)*(amount3 - amount6) + (block9 - block7)*(amount3 - amount6 + amount7)
+        const userCDepositAge = (block6 - block3)*amount3 + (block7 - block6)*(amount3 - amount6) + (block9 - block7)*(amount3 - amount6 + amount7)
         const totalDepositAge = userADepositAge + userBDepositAge + userCDepositAge
 
         beforeEach(() => {
@@ -576,9 +579,9 @@ describe('random scenarios', () => {
         const block11 = 60
         const block12 = 100
 
-        const userADepositAge1 = (block5 - block1)*(amount1 - amount4) + (block9 - block5)*(amount1 - amount4 + amount5 - amount8) 
+        const userADepositAge1 = (block4 - block1)*amount1 + (block5 - block4)*(amount1 - amount4) + (block8 - block5)*(amount1 - amount4 + amount5) + (block9 - block8)*(amount1 - amount4 + amount5 - amount8)
         const userBDepositAge1 = (block9 - block2)*amount2
-        const userCDepositAge1 = (block7 - block3)*(amount3 - amount6) + (block9 - block7)*(amount3 - amount6 + amount7)
+        const userCDepositAge1 = (block6 - block3)*amount3 + (block7 - block6)*(amount3 - amount6) + (block9 - block7)*(amount3 - amount6 + amount7)
         const totalDepositAge1 = userADepositAge1 + userBDepositAge1 + userCDepositAge1
 
         const userADepositAge2 = (block12 - block9)*(amount1 - amount4 + amount5 - amount8 + reward1*userADepositAge1/totalDepositAge1)
@@ -611,7 +614,7 @@ describe('random scenarios', () => {
         test('doesnt affect rewards',()=>{
             expect(contract.userBalance(userA)).toBeCloseTo(amount1 - amount4 + amount5 - amount8 + reward1*userADepositAge1/totalDepositAge1 + reward2*userADepositAge2/totalDepositAge2, 8)
             expect(contract.userBalance(userB)).toBeCloseTo(amount2 + amount11 + reward1*userBDepositAge1/totalDepositAge1 + reward2*userBDepositAge2/totalDepositAge2, 8)
-            expect(contract.userBalance(userC)).toBeCloseTo(amount3 - userC + userC + reward1*userCDepositAge1/totalDepositAge1 + reward2*userCDepositAge2/totalDepositAge2, 8)
+            expect(contract.userBalance(userC)).toBeCloseTo(amount3 - amount6 + amount7 + reward1*userCDepositAge1/totalDepositAge1 + reward2*userCDepositAge2/totalDepositAge2, 8)
             expect(contract.userBalance(userD)).toBeCloseTo(amount10 + reward2*userDDepositAge2/totalDepositAge2, 8)
         })
     })


### PR DESCRIPTION
1. Implemented a deposit-age based expected reward calculation strategy for reward distribution.
2. Fixed the logic in a few tests.

**Nuance**. Some tests will fail because final values end up not 100% as they should be, based on the final deposit-age proportions. That's because whenever a third depositor comes in, the proportion between deposit-ages of the first two depositors actually changes too. There is no O(1) way to account for that, but the error seems to be very small anyways.

**Nuance 2**. There is an operation flushing a mapping in `distribute()`:
`this.userDepositChanged = {}`
It is a non-O(1) operation to actually flush a mapping, but I see two ways around it:
A. Implement `this.userDepositChanged` as a mapping of mappings, incrementing the index after every distribution. This way after every distribution we will effectively have a fresh mapping. The side-effect is certain consumption of space, which is never freed up.
B. Forbid deposits/withdrawals in the reward distribution block. This way we can remove the `userDepositChanged` mapping altogether and only use the block numbers in `this.userDALastUpdated` and `this.lastRewardBlock` to account for user deposit status. The side-effect is potentially bad user experience when their deposit/withdrawal transaction unexpectedly fails. Not sure if there is a reliable way to prevent this.